### PR TITLE
Add Dockerfile and usage instructions for YAML to PDF cards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use Python slim image
+FROM python:3.11-slim
+
+# Install dependencies
+RUN pip install --no-cache-dir PyYAML reportlab
+
+# Copy application
+COPY yaml-to-pdf.py /app/yaml-to-pdf.py
+
+# Set working directory for user data
+WORKDIR /data
+
+# Run the script by default
+ENTRYPOINT ["python", "/app/yaml-to-pdf.py"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Daggerheart YAML to PDF Cards
+
+This repository contains `yaml-to-pdf.py`, a script that converts YAML card definitions into a printable PDF sheet.
+
+## Docker Image
+
+A `Dockerfile` is provided to run the script in a containerized environment.
+
+### Build the Image
+
+```bash
+docker build -t yaml-to-pdf .
+```
+
+### Run the Container
+
+Mount a directory containing your YAML file and specify input and output paths inside the container:
+
+```bash
+docker run --rm -v $(pwd):/data yaml-to-pdf /data/example.yaml -o /data/output.pdf
+```
+
+Replace `/data/example.yaml` with your input file and `/data/output.pdf` with the desired output path. The generated PDF will appear in your local directory because it is mounted into the container at `/data`.


### PR DESCRIPTION
## Summary
- Add Dockerfile to containerize `yaml-to-pdf.py`
- Document how to build and run the container in README

## Testing
- `python -m py_compile yaml-to-pdf.py`
- `python yaml-to-pdf.py example.yaml -o test.pdf` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install PyYAML reportlab` *(fails: Could not find a version that satisfies the requirement PyYAML)*

------
https://chatgpt.com/codex/tasks/task_e_68b235a5ad34832b81b5ce0bf16d9ff4